### PR TITLE
Add error message if PossibleModel cannot deserialize

### DIFF
--- a/src/Model.js
+++ b/src/Model.js
@@ -564,6 +564,12 @@ Model.deserialize = function(pojo, options = {}) {
         let PossibleModel = options.modelMapper(value, options);
 
         if (PossibleModel !== value) {
+          if (!PossibleModel || !PossibleModel.deserialize) {
+            console.error(`Model.options.modelMapper: could not deserialize because provided modelMapper returned a model with no deserialize method.`)
+            console.error(`ModelMapper: ${options.modelMapper}`);
+            console.error(`Value to deserialize:`, value);
+            console.error(`PossibleModel:`, PossibleModel);
+          }
           return PossibleModel.deserialize(value, Object.assign(options, {
             model: PossibleModel
           }));


### PR DESCRIPTION
Ran into an issue where the modelMapper function didn't have a case for
the object passed in and it returned undefined.  The existing error
messages weren't very descriptive or helpful in tracking down the issue.

Would like to improve these messages further -- doesn't seem ideal to
fire four console.errors for one issue, but I wanted the message to be
descriptive and show as much relevant information as possible